### PR TITLE
Add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: bash
+dist: xenial
+os: linux
+
+addons:
+  apt:
+    packages:
+      - libxml2-utils
+      - shunit2
+
+notifications:
+  email:
+    false
+
+script:
+  - cd tests
+  - ./validate_records.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# collection_records
+# Collection_records
+
+![Travis Badge](https://travis-ci.org/UTKcataloging/collection_records.png)
+
 Repository for collection-level records that aren't associated with an existing repository (particularly non-Islandora collections).

--- a/tests/test_schemas/schemas.xsd
+++ b/tests/test_schemas/schemas.xsd
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema">
+    <import namespace="http://www.loc.gov/mods/v3" schemaLocation="http://www.loc.gov/standards/mods/v3/mods-3-5.xsd"/>
+</schema>

--- a/tests/validate_records.sh
+++ b/tests/validate_records.sh
@@ -1,0 +1,16 @@
+SCHEMAS="test_schemas/schemas.xsd"
+COLLECTION_RECORDS="../collection_records"
+
+
+testShunitIntalled() {
+    assertNotNull $(which shunit2)
+}
+
+testIfCollectionRecordsValid() {
+    for filename in $COLLECTION_RECORDS/*.xml; do
+        RESPONSE=$(xmllint --noout --schema ${SCHEMAS} ${filename} 2>&1 1>/dev/null | cat)
+        assertEquals "${RESPONSE}" "${filename} validates"
+    done
+}
+
+. shunit2


### PR DESCRIPTION
What does this do
==============

Adds tests to check that collection records are valid and well-formed prior to ingest into Fedora.

Travis says this is failing
==================

It sure does, but that's not because of this pull request.  It's because of problems in previous edits to this repo.  You can see those below.

Errors
=====

There are currently several errors throughout this repository. You can see those by clicking the Travis details selection below.

1. [ekcd.xml](https://travis-ci.org/github/UTKcataloging/collection_records/builds/698684117#L164): type attribute is not allowed on [subject node](https://github.com/UTKcataloging/collection_records/blob/master/collection_records/ekcd.xml#L32).
2. [kintner.xml](https://travis-ci.org/github/UTKcataloging/collection_records/builds/698684117#L166): geographic is misspelled twice: [1](https://github.com/UTKcataloging/collection_records/blob/master/collection_records/kintner.xml#L32) and [2](https://github.com/UTKcataloging/collection_records/blob/master/collection_records/kintner.xml#L35).
3. [wwiioh.xml](https://travis-ci.org/github/UTKcataloging/collection_records/builds/698684117#L169): authority is misspelled twice: [1](https://github.com/UTKcataloging/collection_records/blob/master/collection_records/wwiioh.xml#L31) and [2](https://github.com/UTKcataloging/collection_records/blob/master/collection_records/wwiioh.xml#L36).